### PR TITLE
I had to import StringIO for it to work on my machine? Not sure if my…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,19 @@ Run from your git repo:
 ```
 $ ruby ~/gitConflicts/conflicts.rb
 ```
+```
+$ ruby ~/gitConflicts/conflicts.rb ui/orion
+```
 Output:
 
 ```
 You and Steven Farberov are both modifying the files: src/features/campaign-manage/components/ManageBladeTabs/SomeFile.js
 See Steven Farberov's commit "This is a commit msg" at https://gerrit.rfiserve.net/1234
 ```
+
+### Quick Run
+Add an alias within your bashrc or zshrc config
+```
+alias conflicts='ruby /Users/userName/path-to-repo/Git-Soft-Conflicts/conflicts.rb'
+```
+Then simply run `conflicts` to save yourself time. 


### PR DESCRIPTION
… computer is just weird.

I'd like to use this in the automation repo, so I added the ability to pass an argument for any RF repo. No argument defaults to Orion.

I added a log message if there are no conflicts.